### PR TITLE
python createAccount.py: Return proper error instead of always 'Missing file'

### DIFF
--- a/Resources/data/pyPumukit/createAccount.py
+++ b/Resources/data/pyPumukit/createAccount.py
@@ -2,11 +2,13 @@
 
 import httplib2_monkey_patch  # noqa: F401
 
+import sys
 
 from oauth2client.file import Storage
 from oauth2client.client import flow_from_clientsecrets
 from oauth2client.tools import run_flow
 from oauth2client.tools import argparser
+from oauth2client.clientsecrets import InvalidClientSecretsError
 
 CLIENT_SECRETS_FILE = "client_secrets.json"
 OAUTH_TOKEN_FILE = "oauth2.json"
@@ -14,9 +16,12 @@ SCOPE_YOUTUBE = "https://www.googleapis.com/auth/youtube"
 SCOPE_YOUTUBE_MANAGE = "https://www.googleapis.com/auth/youtubepartner"
 SCOPE = [SCOPE_YOUTUBE, SCOPE_YOUTUBE_MANAGE]
 
-flow = flow_from_clientsecrets(CLIENT_SECRETS_FILE,
-                        scope=SCOPE,
-                        message="Missing client_secrets.json")
+try:
+    flow = flow_from_clientsecrets(CLIENT_SECRETS_FILE,
+                                   scope=SCOPE)
+except InvalidClientSecretsError as e:
+    print("Error when reading file {0}: {1}".format(CLIENT_SECRETS_FILE, e))
+    sys.exit()
 
 storage = Storage(OAUTH_TOKEN_FILE)
 credentials = storage.get()


### PR DESCRIPTION
When the client_secrets.json file does not have the required format, the createAccount.py script always returns "Missing client_secrets.json" instead of the actual error.

This leads to confusion, so here is a quick change letting the `flow_from_clientsecrets` function throw an exception and printing the error.